### PR TITLE
Change to use alternative mathjax hosting

### DIFF
--- a/1.html
+++ b/1.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/10.html
+++ b/10.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/11.html
+++ b/11.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/12.html
+++ b/12.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/13.html
+++ b/13.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({
@@ -458,7 +458,7 @@
 
         <section>
         <p>
-        さて<a href="http://nineties.github.io/prml-seminar/11.html#/14">第11回の公式</a>を用いれば  $\mathbf{w}$ の事後分布は
+        さて<a href="https://nineties.github.io/prml-seminar/11.html#/14">第11回の公式</a>を用いれば  $\mathbf{w}$ の事後分布は
         \[ p(\mathbf{w}|\mathbf{t},\mathbf{D},\boldsymbol{\alpha},\beta)\propto L(\mathbf{w})p(\mathbf{w}|\boldsymbol{\alpha})=\mathcal{N}(\mathbf{w}|\mathbf{m},\mathbf{\Sigma}) \]
         \[ \begin{aligned}
         \mathbf{m} &= \beta \mathbf{\Sigma}\mathbf{X}^T\mathbf{t}\\

--- a/14.html
+++ b/14.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/15.html
+++ b/15.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/16.html
+++ b/16.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/17.html
+++ b/17.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/18.html
+++ b/18.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/19.html
+++ b/19.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/2.html
+++ b/2.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/20.html
+++ b/20.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/21.html
+++ b/21.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/22.html
+++ b/22.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/23.html
+++ b/23.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/3.html
+++ b/3.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({
@@ -164,7 +164,7 @@
         <p>
         回帰分析に最小二乗法を利用した場合は, 学習データ数を $n$, 残差平方和を $RSS$ として
         \[ \mathrm{AIC}\approx n\ln\left(\frac{RSS}{n}\right)+2M+\mathrm{const}.\]
-        となります.(<a href="http://nineties.github.io/math-seminar/17.html#/34">参考</a>)
+        となります.(<a href="https://nineties.github.io/math-seminar/17.html#/34">参考</a>)
         </p>
         <p>
         前回と同じフィッティングの問題で計算してみましょう.
@@ -345,7 +345,7 @@
         \mathbf{X} &= (\Psi(\mathbf{x}_1),\Psi(\mathbf{x}_2),\ldots,\Psi(\mathbf{x}_m))^T \\
         \mathbf{y} &= (y_1,y_2,\ldots,y_n)^T
         \end{aligned} \]
-        です(<a href="http://nineties.github.io/prml-seminar/1.html#/80">参考</a>).
+        です(<a href="https://nineties.github.io/prml-seminar/1.html#/80">参考</a>).
         </p>
         </section>
 

--- a/4.html
+++ b/4.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/5.html
+++ b/5.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({
@@ -353,7 +353,7 @@
         この単純なニュートン・ラフソン法では必ずしも極小値に収束するとは限らず極大値に収束したり発散してしまう場合があります。そこで準ニュートン法というものが登場しますが、これは後の回に説明します。
         </p>
         <p class="fragment" style="font-size:80%">
-        一変数方程式 $f'(x)=0$ にニュートン・ラフソン法(<a href="http://nineties.github.io/math-seminar/4.html">参考</a>) を適用すると
+        一変数方程式 $f'(x)=0$ にニュートン・ラフソン法(<a href="https://nineties.github.io/math-seminar/4.html">参考</a>) を適用すると
         \[ x_{k+1} = x_k - \frac{f'(x_k)}{f''(x_k)} \]
         という反復公式が得られますが, これを多変数に拡張したものです. 二次収束します.
         </p>

--- a/6.html
+++ b/6.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/7.html
+++ b/7.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/8.html
+++ b/8.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({
@@ -157,7 +157,7 @@
         <p>
         例えば, <strong> 中心差分法 (central difference) </strong> では, 微小量 $\varepsilon &gt; 0$ に対して
         \[ \frac{\partial E}{\partial w_{ji}} = \frac{E(w_{ji} + \varepsilon)-E(w_{ji} - \varepsilon)}{2\varepsilon} + O(\varepsilon^2) \]
-        となります(<a href="http://nineties.github.io/math-seminar/3.html#/39">参考</a>).
+        となります(<a href="https://nineties.github.io/math-seminar/3.html#/39">参考</a>).
         </p>
         <p class="fragment">
         各微分係数の計算に2回の順伝播が必要なので, 計算量は重みの数 $W$ に対して $\mathcal{O}(W^2)$ となります.

--- a/9.html
+++ b/9.html
@@ -28,7 +28,7 @@
 		</script>
 
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({


### PR DESCRIPTION
As stated in [the official site](https://www.mathjax.org/cdn-shutting-down/), `cdn.mathjax.org` will be shutdown and it is recommended to use `cdnjs.cloudflare.com` instead. And the mathjax script can't be loaded properly because it is blocked by "mixed content" error ([details](https://developer.mozilla.org/ja/docs/Security/%E6%B7%B7%E5%9C%A8%E3%82%B3%E3%83%B3%E3%83%86%E3%83%B3%E3%83%84/How_to_fix_website_with_mixed_content)).